### PR TITLE
Callback hell (#7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND headers
 
 	"src/ConcurrentQueue.hpp"
 	"src/SwitchBuffer.hpp"
+	"src/Chain.hpp"
 )
 	
 list(APPEND sources 
@@ -36,6 +37,7 @@ list(APPEND sources
 	"src/Request.cpp"
 	"src/Response.cpp"
 	"src/Config.cpp"
+	"src/Chain.cpp"
 	
 	"src/Console.cpp"
 	"src/Blizzard.cpp"

--- a/src/Chain.cpp
+++ b/src/Chain.cpp
@@ -1,0 +1,40 @@
+#include "Chain.hpp"
+#include <cassert>
+
+Chain& Chain::Add(Chain::Callback cb) {
+    assert(cb); 
+    return Add(
+        [](Chain::Callback arg) { std::invoke(arg); }
+        , std::move(cb)
+    );
+}
+
+Chain& Chain::Add(Chain::Task task, Chain::Callback cb) {
+    // `hook` will be executed in `task` instead of original callback `cb`
+    auto hook = [self = shared_from_this(), cb = std::move(cb)](){
+        if (cb) cb();
+        self->Execute();
+    };
+    chain_.emplace_back(std::move(task), std::move(hook));
+
+    if (current_ == chain_.end()) {
+        current_ = chain_.begin();
+    }
+    return *this;
+}
+
+void Chain::Execute() {
+    if (current_ == chain_.end()) {
+        // all tasks are completed
+        return;
+    }
+
+    auto prev = current_++;
+    try {
+        std::invoke(prev->task, std::move(prev->cb));
+    }
+    catch (...) {
+        --current_;
+        throw;
+    }
+}

--- a/src/Chain.cpp
+++ b/src/Chain.cpp
@@ -1,40 +1,37 @@
 #include "Chain.hpp"
 #include <cassert>
 
+Chain::Chain(std::shared_ptr<boost::asio::io_context> context)
+    : context_{ context }
+{
+    assert(context_);
+}
+
 Chain& Chain::Add(Chain::Callback cb) {
     assert(cb); 
-    return Add(
-        [](Chain::Callback arg) { std::invoke(arg); }
+    return Add([](Chain::Callback arg) { std::invoke(arg); }
         , std::move(cb)
     );
 }
 
 Chain& Chain::Add(Chain::Task task, Chain::Callback cb) {
     // `hook` will be executed in `task` instead of original callback `cb`
-    auto hook = [self = shared_from_this(), cb = std::move(cb)](){
+    auto hook = [self = shared_from_this(), cb = std::move(cb)]() {
         if (cb) cb();
-        self->Execute();
+        if (!self->chain_.empty()) self->Execute();
     };
     chain_.emplace_back(std::move(task), std::move(hook));
-
-    if (current_ == chain_.end()) {
-        current_ = chain_.begin();
-    }
     return *this;
 }
 
 void Chain::Execute() {
-    if (current_ == chain_.end()) {
-        // all tasks are completed
-        return;
-    }
+    assert(!chain_.empty());
 
-    auto prev = current_++;
-    try {
-        std::invoke(prev->task, std::move(prev->cb));
-    }
-    catch (...) {
-        --current_;
-        throw;
-    }
+    boost::asio::post(*context_, [self = shared_from_this()]() {
+        assert(!self->chain_.empty());
+
+        auto ctx { std::move(self->chain_.front()) };
+        self->chain_.pop_front();
+        std::invoke(ctx.task, std::move(ctx.cb)); 
+    });
 }

--- a/src/Chain.hpp
+++ b/src/Chain.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include <list>
+#include <memory>
+#include <functional>
+
+/**
+ * Chain MUST NOT (and IS NOT) observed by more than 1 thread at once
+ * TODO: remove already completed tasks from the chain
+ */
+class Chain : public std::enable_shared_from_this<Chain> {
+public:
+    using Callback = std::function<void()>;
+    using Task = std::function<void(Callback)>;
+
+    Chain& Add(Callback cb);
+
+    Chain& Add(Task task, Callback cb = {});
+
+    void Execute();
+
+private:
+
+    struct Bind {
+        Bind(Task task, Callback cb)
+            : task { std::move(task) }
+            , cb { std::move(cb) }
+        {}
+
+        Task task;
+        // callback is being passed to task as parameter via std::move
+        // and will be destroyed with task. 
+        Callback cb;
+    };
+
+    std::list<Bind> chain_;
+    // points to the first task to be executed
+    std::list<Bind>::iterator current_ { chain_.end() };
+};

--- a/src/Chain.hpp
+++ b/src/Chain.hpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <functional>
 
+#include <boost/asio.hpp>
+
 /**
  * Chain MUST NOT (and IS NOT) observed by more than 1 thread at once
  * TODO: remove already completed tasks from the chain
@@ -11,6 +13,8 @@ class Chain : public std::enable_shared_from_this<Chain> {
 public:
     using Callback = std::function<void()>;
     using Task = std::function<void(Callback)>;
+
+    Chain(std::shared_ptr<boost::asio::io_context> context);
 
     Chain& Add(Callback cb);
 
@@ -32,7 +36,6 @@ private:
         Callback cb;
     };
 
+    std::shared_ptr<boost::asio::io_context> context_;
     std::list<Bind> chain_;
-    // points to the first task to be executed
-    std::list<Bind>::iterator current_ { chain_.end() };
 };

--- a/src/Twitch.cpp
+++ b/src/Twitch.cpp
@@ -5,6 +5,7 @@
 #include "Command.hpp"
 #include "Utility.hpp"
 #include "Alias.hpp"
+#include "Chain.hpp"
 
 #include "rapidjson/document.h"
 
@@ -248,46 +249,51 @@ void Twitch::Invoker::Execute(command::Validate) {
     if (!secret) {
         throw std::runtime_error("Fail to create config");
     }
-    auto onConnect = [request = twitch::Validation{ secret->token_ }.Build()
-        , twitchService = twitch_
-        , connection = utils::WeakFrom<HttpConnection>(connection)
-    ]() {
-        assert(connection.use_count() == 1 && 
-            "Fail invariant:"
-            "Expected: 1 ref - instance which is executing Connection::OnWrite"
-            "Assertion Failure may be caused by changing the "
-            "(way)|(place where) this callback is being invoked"
-        );
-        auto shared = connection.lock();
-        shared->ScheduleWrite(std::move(request), [twitchService, connection]() {
-            assert(connection.use_count() == 1);
 
-            auto OnReadSuccess = [twitchService, connection]() {
-                assert(connection.use_count() == 1);
-                
-                auto shared = connection.lock();
-                const auto [head, body] = shared->AcquireResponse();
-                if (head.statusCode_ == 200) {
-                    rapidjson::Document json; 
-                    json.Parse(body.data(), body.size());
-                    auto login = json["login"].GetString();
-                    auto expiration = json["expires_in"].GetUint64();
-                    Console::Write("[twitch] validation success. Login:", login, "Expire in:", expiration, '\n');
-                }
-                else {
-                    Console::Write("[ERROR] [twitch] validation failed. Status:"
-                        , head.statusCode_
-                        , head.reasonPhrase_
-                        , '\n', body, '\n'
-                    );
-                }
-            };
-
-            auto shared = connection.lock();
-            shared->Read(std::move(OnReadSuccess));
-        });
+    auto weak = utils::WeakFrom<HttpConnection>(connection);
+    auto connect = [weak](Chain::Callback cb) {
+        assert(weak.use_count() == 1);
+        auto shared = weak.lock();
+        shared->Connect(std::move(cb));
     };
-    connection->Connect(std::move(onConnect));
+
+    auto request = twitch::Validation{ secret->token_ }.Build();
+    auto write = [weak, request = std::move(request)](Chain::Callback cb) {
+        assert(weak.use_count() == 1);
+        auto shared = weak.lock();
+        shared->ScheduleWrite(std::move(request), std::move(cb));
+    };
+    
+    auto read = [weak](Chain::Callback cb) {
+        assert(weak.use_count() == 1);
+        auto shared = weak.lock();
+        shared->Read(std::move(cb));
+    };
+    
+    auto readCallback = [weak](){
+        auto shared = weak.lock();
+        const auto [head, body] = shared->AcquireResponse();
+        if (head.statusCode_ == 200) {
+            rapidjson::Document json; 
+            json.Parse(body.data(), body.size());
+            auto login = json["login"].GetString();
+            auto expiration = json["expires_in"].GetUint64();
+            Console::Write("[twitch] validation success. Login:", login, "Expire in:", expiration, '\n');
+        }
+        else {
+            Console::Write("[ERROR] [twitch] validation failed. Status:"
+                , head.statusCode_
+                , head.reasonPhrase_
+                , '\n', body, '\n'
+            );
+        }
+    };
+
+    auto chain = std::make_shared<Chain>();
+    (*chain).Add(std::move(connect))
+        .Add(std::move(write))
+        .Add(std::move(read), std::move(readCallback))
+        .Execute();
 }
 
 void Twitch::Invoker::Execute(command::Shutdown) {
@@ -356,17 +362,27 @@ void Twitch::Invoker::Execute(command::Login cmd) {
         , id
     );
 
-    auto onConnect = [request = twitch::IrcAuth{cmd.token_, cmd.user_}.Build()
-        , twitchService = twitch_
-        , irc = twitch_->irc_.get()
-    ]() {
-        irc->ScheduleWrite(std::move(request), [twitchService, irc]() {
-            irc->Read([twitchService, irc]() {
-                twitchService->HandleResponse(irc->AcquireResponse());
-            });
-        });
+    auto request = twitch::IrcAuth{cmd.token_, cmd.user_}.Build();
+    auto irc = twitch_->irc_.get();
+    auto readCallback = [irc, twitch = twitch_](){
+        twitch->HandleResponse(irc->AcquireResponse());
     };
-    twitch_->irc_->Connect(std::move(onConnect));
+
+    auto connect = [irc](Chain::Callback cb) {
+        irc->Connect(std::move(cb));
+    };
+    auto write = [irc, request = std::move(request)](Chain::Callback cb) {
+        irc->ScheduleWrite(std::move(request), std::move(cb));
+    };
+    auto read = [irc](Chain::Callback cb){
+        irc->Read(std::move(cb));
+    };
+
+    auto chain = std::make_shared<Chain>();
+    (*chain).Add(std::move(connect))
+        .Add(std::move(write))
+        .Add(std::move(read), std::move(readCallback))
+        .Execute();
 }
 
 void Twitch::Invoker::Execute(command::RealmStatus cmd) {


### PR DESCRIPTION
Add task chaining where task is any function with following signature: `void(Callback)` where `Callback` is a functions which has `void()` signature. Callback is needed because it's used as a signal that the task is almost completed and the next one can be passed for execution.

Chaining uses `boost::asio::post(...)` with `boost::asio::io_context` passing task to queue for execution. 
Chain keeps tasks and callbacks in the list so it's not as efficient as creating callbacks on the stack as local variables on execution (this is what callbacks hell does). Nevertheless it provides simple syntax:
```c++
auto chain = std::make_shared<Chain>(context_);
(*chain).Add(std::move(connect))
    .Add(std::move(write))
    .Add(std::move(read), std::move(readCallback))
    .Add(std::move(continuation))
    .Execute();
```
Chaining is limited by "task" signature and prefers"tasks" to be independent from each other. Tasks are executed one by one in sequence and they can only pass data between themselves through external (for them) variables.

close #7 