### PR TITLE
Add Rate Limit for Twitch IRC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND headers
 	"src/Translator.hpp"
 	"src/Command.hpp"
 	"src/Alias.hpp"
+	"src/IrcShard.hpp"
 	
 	"src/Console.hpp"
 	"src/Blizzard.hpp"
@@ -42,6 +43,7 @@ list(APPEND sources
 	"src/Chain.cpp"
 	"src/Alias.cpp"
 	"src/Utility.cpp"
+	"src/IrcShard.cpp"
 	
 	"src/Console.cpp"
 	"src/Blizzard.cpp"

--- a/README.md
+++ b/README.md
@@ -112,13 +112,21 @@ Arena leaderboard is one of the most interesting thing for WOW community so it w
 ### Restrictions
 
 There are several very imporatant restriction on the communication in twitch chat. They depend on MODE and Bot authority.
-Bot doesn't consider twitch restrictions yet. Following restriction will be implemented soon:
+Bot doesn't consider some twitch restrictions yet.  
+
+**NOT implemented yet:**
 
 - Minimum 1 second delay between messages via IRC connection. For slow mode it can be greater.
-- 30 messages for 1 second
 - Authority e.g., subscriber mode, etc
 
-If IRC or HTTPS connection fails to connect/read/write it will try to reconnect 3 times with 2s, 4s, 8s timeouts. if you're not managing connection's lifetime by yourself it will be destroyed on failure to reconnect.
+**ALREADY implemented:**
+
+- [Rate Limit](https://dev.twitch.tv/docs/irc/guide) is used for **PRIVMSG**, **JOIN**, **PASS**.  
+Only 2 buckets with the strictest restrictions supported now: general bucket(**JOIN**, **PASS**), channel bucket(**PRIVMSG**).
+Buckets doesn't take into account users authority and assuming this is simple account. Now you're neither moderator neither subscriber. Authority support is not implemented.
+Buckets doesn't take into account bans, slowmodes, etc. These features will be implemented later.
+
+If IRC or HTTPS connection fails to connect/read/write it will try to reconnect 3 times with 2s, 4s, 8s timeouts.
 
 ## Certificate Authorities
 

--- a/src/Alias.cpp
+++ b/src/Alias.cpp
@@ -27,13 +27,13 @@ void AliasTable::Add(const Alias& alias
 
 std::optional<AliasTable::CommandLine> AliasTable::GetCommand(
     std::string_view alias
-) {
-    auto it = std::find_if(aliases_.begin(), aliases_.end()
+) const {
+    auto it = std::find_if(aliases_.cbegin(), aliases_.cend()
         , [&alias](const Bind& other) {
             return other.alias == alias;
         });
 
-    if (it != aliases_.end()) {
+    if (it != aliases_.cend()) {
         return std::make_optional(CommandLine{ it->command, it->params });
     }
     return std::nullopt;

--- a/src/Alias.hpp
+++ b/src/Alias.hpp
@@ -38,7 +38,7 @@ public:
 
     void Add(const Alias& alias, const Command& cmd, const Params& params);
 
-    std::optional<CommandLine> GetCommand(std::string_view alias);
+    std::optional<CommandLine> GetCommand(std::string_view alias) const;
 
     bool Remove(const Alias& alias) noexcept;
 

--- a/src/App.hpp
+++ b/src/App.hpp
@@ -23,7 +23,6 @@ using boost::asio::ip::tcp;
 
 class App {
 public:
-    using Container = CcQueue<command::RawCommand, cst::kQueueCapacity>;
 
     App() 
         : commands_ { kSentinel }
@@ -105,7 +104,7 @@ private:
 
     std::vector<std::thread> workers_;
     // common queue
-    Container commands_;
+    command::Queue commands_;
     Translator translator_;
     // configuration and settings
     Config config_;

--- a/src/App.hpp
+++ b/src/App.hpp
@@ -67,6 +67,7 @@ public:
         // create consumers
         for (std::size_t i = 0; i < kWorkerCount; i++) {
             workers_.emplace_back([this]() {
+                // TODO: this stuff in while loop may throw
                 while (true) {
                     auto cmd { commands_.TryPop() };
                     if (!cmd) {
@@ -78,7 +79,12 @@ public:
                         params.reserve(cmd->params_.size());
                         for (auto&& [k, v]: cmd->params_) {
                             params.emplace_back(command::ParamView{ k, v });
-                        }        
+                        }
+                        // TODO: this stuff may throw run-time errors, see: 
+                        // <code> // IrcShard.cpp
+                        // void IrcShard::Invoker::Execute(command::Validate);
+                        // </code>
+                        // maybe you should try to catch and process this exception?
                         std::invoke(*handle, params);
                     }
                     else {

--- a/src/Blizzard.cpp
+++ b/src/Blizzard.cpp
@@ -15,7 +15,7 @@ namespace domain = blizzard::domain;
 
 namespace service {
 
-Blizzard::Blizzard(const Config *config, Container * outbox) 
+Blizzard::Blizzard(const Config *config, command::Queue * outbox) 
     : context_ { std::make_shared<boost::asio::io_context>() }
     , work_ { context_->get_executor() }
     , ssl_ { std::make_shared<ssl::context>(ssl::context::method::sslv23_client) }

--- a/src/Blizzard.hpp
+++ b/src/Blizzard.hpp
@@ -26,9 +26,7 @@ class Blizzard
     : public std::enable_shared_from_this<Blizzard> 
 {
 public:
-    using Container = CcQueue<command::RawCommand, cst::kQueueCapacity>;
-    
-    Blizzard(const Config *config, Container * outbox);
+    Blizzard(const Config *config, command::Queue *outbox);
 
     Blizzard(const Blizzard&) = delete;
     Blizzard(Blizzard&&) = delete;
@@ -78,7 +76,7 @@ private:
 
     std::unique_ptr<Invoker> invoker_;
     const Config * const config_ { nullptr };
-    Container * const outbox_ { nullptr };
+    command::Queue * const outbox_ { nullptr };
     
     // connection id
     static inline size_t lastID_ { 0 };

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -135,6 +135,10 @@ namespace command {
         return { ::Find(args, "channel") };
     }
 
+    Ping Ping::Create(const service::Twitch&, const Args& args) {
+        return { ::Find(args, "channel") };
+    }
+
     Leave Leave::Create(const service::Twitch&, const Args& args) {
         return { ::Find(args, "channel") };
     }

--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -107,6 +107,12 @@ namespace command {
         }
     };
 
+    struct Ping {
+        std::string channel_;
+        
+        static Ping Create(const service::Twitch&, const Args&);
+    };
+
     struct Chat {
         std::string channel_;
         std::string message_;
@@ -170,6 +176,7 @@ namespace command {
                 || std::is_same_v<T, Join>
                 || std::is_same_v<T, Leave>
                 || std::is_same_v<T, Pong>
+                || std::is_same_v<T, Ping>
                 || std::is_same_v<T, RealmStatus> // pass it to the next layer (App)
                 || std::is_same_v<T, Arena> // pass it to the next layer (App)
                 || std::is_same_v<T, Chat>

--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -6,6 +6,9 @@
 #include <string>
 #include <cassert>
 
+#include "Environment.hpp"
+#include "ConcurrentQueue.hpp"
+
 namespace service {
     class Blizzard;
     class Twitch;
@@ -45,7 +48,11 @@ namespace command {
         std::vector<ParamData> params_;
     };
 
+    using Queue = CcQueue<command::RawCommand, cst::kQueueCapacity>;
+
     struct Alias {
+        static constexpr std::string_view kIdentity = "alias";
+
         std::string alias_;
         std::string command_;
         std::vector<ParamData> params_;
@@ -54,6 +61,8 @@ namespace command {
     };
 
     struct RealmID {
+        static constexpr std::string_view kIdentity = "realm-id";
+
         static RealmID Create(const service::Blizzard&, const Args&) {
             return {};
         }
@@ -63,6 +72,8 @@ namespace command {
     // passed by Twitch service to Blizzard
     // executed by Blizzard service: acquire data from the remote server
     struct RealmStatus {
+        static constexpr std::string_view kIdentity = "realm-status";
+
         std::string channel_;
         // initiator of the command
         std::string user_;
@@ -72,6 +83,8 @@ namespace command {
     };
 
     struct Arena {
+        static constexpr std::string_view kIdentity = "arena";
+
         std::string channel_;
         std::string user_;
         std::string player_;
@@ -81,18 +94,24 @@ namespace command {
     };
 
     struct AccessToken {
+        static constexpr std::string_view kIdentity = "token";
+
         static AccessToken Create(const service::Blizzard&, const Args&) {
             return {};
         }
     };
 
     struct Shutdown {
+        static constexpr std::string_view kIdentity = "shutdown";
+
         static Shutdown Create(const service::Console&, const Args&) {
             return {};
         }
     };
 
     struct Help {
+        static constexpr std::string_view kIdentity = "help";
+
         static Help Create(const service::Console&, const Args&) {
             return {};
         }
@@ -102,18 +121,24 @@ namespace command {
     };
     
     struct Pong {
+        static constexpr std::string_view kIdentity = "pong";
+
         static Pong Create(const service::Twitch&, const Args&) {
             return {};
         }
     };
 
     struct Ping {
+        static constexpr std::string_view kIdentity = "ping";
+
         std::string channel_;
         
         static Ping Create(const service::Twitch&, const Args&);
     };
 
     struct Chat {
+        static constexpr std::string_view kIdentity = "chat";
+
         std::string channel_;
         std::string message_;
 
@@ -121,6 +146,8 @@ namespace command {
     };
 
     struct Join {
+        static constexpr std::string_view kIdentity = "join";
+
         // https://datatracker.ietf.org/doc/html/rfc1459.html#section-1.3
         std::string channel_;
 
@@ -128,18 +155,24 @@ namespace command {
     };
 
     struct Leave {
+        static constexpr std::string_view kIdentity = "leave";
+
         std::string channel_;
 
         static Leave Create(const service::Twitch& ctx, const Args& params);
     };
 
     struct Validate {
+        static constexpr std::string_view kIdentity = "validate";
+
         static Validate Create(const service::Twitch&, const Args&) {
             return {};
         }
     };
 
     struct Login {
+        static constexpr std::string_view kIdentity = "login";
+
         std::string user_;
         std::string token_;
 

--- a/src/ConcurrentQueue.hpp
+++ b/src/ConcurrentQueue.hpp
@@ -39,7 +39,7 @@ public:
             lock.unlock();
             isPushed = true;
             // notify consumers
-            notifier_.notify_all();
+            notifier_.notify_one();
         }
         return isPushed;
     }

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -45,18 +45,24 @@ void Connection::Close() {
 
     socket_->shutdown(error);
     if (error) {
-        log_->Write(LogType::kError, "SSL stream shutdown:", error.message(), '\n');
+        log_->Write(LogType::kError
+            , "SSL stream shutdown:"
+            , error.message(), '\n');
         error.clear();
     }
     if (auto&& ll = socket_->lowest_layer(); ll.is_open()) {
         ll.shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
         if (error) {
-            log_->Write(LogType::kError, "SSL underlying socket shutdown:", error.message(), '\n');
+            log_->Write(LogType::kError
+                , "SSL underlying socket shutdown:"
+                , error.message(), '\n');
             error.clear();
         }
         ll.close(error);
         if (error) {
-            log_->Write(LogType::kError, "SSL underlying socket close:", error.message(), '\n');
+            log_->Write(LogType::kError
+                , "SSL underlying socket close:"
+                , error.message(), '\n');
         }
     } 
 }

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -190,6 +190,9 @@ void Connection::ScheduleWrite(std::string text, std::function<void()> onWrite) 
             self->Write();
         }
     };
+    // [CRITICAL SECTION]
+    // ASSUMED it's thread-safe to `post` completion token through `strand_`
+    // see https://stackoverflow.com/questions/51859895/is-boostasioio-servicepost-atomic/51862417
     boost::asio::post(strand_, std::move(deferredCallee));
 }
 

--- a/src/IrcShard.cpp
+++ b/src/IrcShard.cpp
@@ -1,0 +1,449 @@
+#include "IrcShard.hpp"
+
+#include "Connection.hpp"
+#include "Request.hpp"
+#include "Chain.hpp"
+#include "Console.hpp"
+#include "Config.hpp"
+#include "Twitch.hpp"
+
+#include "rapidjson/document.h"
+
+#include <cassert>
+#include <algorithm>
+#include <stdexcept>
+#include <cctype>
+#include <sstream>
+
+namespace {
+    std::string ExtractBetween(const std::string& src, char left, char right) {
+        const auto leftDelim = src.find(left);
+        const auto rightDelim = src.find(right, leftDelim);
+        if (leftDelim == std::string::npos || rightDelim == std::string::npos) {
+            return {};
+        } 
+        else {
+            return { src.substr(leftDelim + 1, rightDelim - leftDelim - 1) };
+        }
+    }
+
+    inline std::string_view ShiftView(const std::string& src, size_t shift) noexcept {
+        assert(shift < src.size());
+        return { src.data() + shift, src.size() - shift};
+    }
+}
+
+namespace service::twitch {
+
+MessageBucket::MessageBucket(std::uint16_t amount, Seconds rate)
+    : refillAmount_ { amount }
+    , available_ { amount }
+    , refillRate_ { rate }
+    , lastRefillTime_ { std::chrono::steady_clock::now() }
+{}
+
+// Actually, it's not precision approach 
+// cuz we lose some tickets(opportunity to write)
+// but I can avoid using timer
+bool MessageBucket::TryUse() {
+    TimePoint now = std::chrono::steady_clock::now();
+    Seconds elapsed = std::chrono::duration_cast<Seconds>(lastRefillTime_ - now);
+    
+    if (elapsed >= refillRate_) {
+        lastRefillTime_ = now;
+        available_ = refillAmount_;
+    }
+
+    if (available_ > 0) {
+        available_--;
+        return true;
+    }
+    return false;
+}
+
+IrcShard::IrcShard(Twitch *service
+    , command::Queue *rawCommands
+    , command::AliasTable *aliases
+    , SharedIO context
+    , SharedSSL ssl
+) 
+    : buckets_ { 
+        MessageBucket  { kRefillAmount, kGeneralRefillRate }
+        , { kRefillAmount, kChannelRefillRate }
+    }
+    , service_ { service }
+    , commands_ { rawCommands }
+    , aliases_ { aliases }
+    , translator_ {}
+    , context_ { context }
+    , ssl_ { ssl }
+    , invoker_ { std::make_unique<Invoker>(this) }
+{
+    assert(service);
+    assert(rawCommands);
+    assert(context && ssl);
+    
+    using namespace std::literals::string_view_literals;
+    std::initializer_list<Translator::Pair> commands {
+        { "help"sv,         Translator::CreateHandle<command::Help>(*service) },
+        // TODO: rename to pong!
+        { "ping"sv,         Translator::CreateHandle<command::Pong>(*service) },
+        { "arena"sv,        Translator::CreateHandle<command::Arena>(*service) },
+        { "realm-status"sv, Translator::CreateHandle<command::RealmStatus>(*service) }
+    };
+    translator_.Insert(commands);
+
+    const size_t id { 0 };
+    irc_ = std::make_shared<IrcConnection>(context_
+        , ssl_
+        , request::twitch::kHost
+        , request::twitch::kService
+        , id);
+}
+
+IrcShard::~IrcShard() {
+    Reset();
+}
+
+void IrcShard::Reset() {
+    if (irc_) {
+        irc_->ScheduleShutdown();
+        irc_.reset();
+    }
+}
+
+// ===================== RESPONSE ================== //
+void IrcShard::HandlePrivateMessage(net::irc::Message& message) {
+    enum { kChannel, kMessage, kRequiredFields };
+    static_assert(kMessage == 1, "According to IRC format message "
+        "for PRIVMSG command is always second parameter"
+        "(numeration starting with 0)");
+    
+    // user command, not IRC command
+    enum Sign : char { kChannelSign = '#', kCommandSign = '!'};
+    auto& ircParams { message.params_ };
+
+    // is user-defined command
+    if (ircParams.size() == kRequiredFields
+        && ircParams[kChannel].front() == kChannelSign
+        && ircParams[kMessage].front() == kCommandSign
+    ) {
+        // chat message is an input from the user in twitch chat
+        auto& chatMessage { ircParams[kMessage] };
+        std::transform(chatMessage.cbegin()
+            , chatMessage.cend()
+            , chatMessage.begin()
+            , [](unsigned char c) { return std::tolower(c); }
+        );
+
+        std::string_view unprocessed { chatMessage };
+        size_t chatCommandEnd = unprocessed.find_first_of(' ');
+        if (chatCommandEnd == std::string_view::npos) {
+            chatCommandEnd = unprocessed.size();
+        }
+        // here we're still not sure whether it's a command or just a coincidence
+        std::string_view chatCommand { unprocessed.data() + 1, chatCommandEnd - 1 };
+        unprocessed.remove_prefix(chatCommandEnd + 1);
+        // divide message to tokens (maybe parameters for the chat command)
+        auto params = command::ExtractArgs(unprocessed, ' ');
+
+        assert(aliases_);
+        // Substitute alias with command and required params if it's alias
+        if (auto referred = aliases_->GetCommand(chatCommand); referred) {
+            Console::Write("[twitch] used alias "
+                , chatCommand, "refers to "
+                , referred->command, '\n');
+            chatCommand = referred->command;
+            for (const auto& [k, v]: referred->params) {
+                const auto& key = k;
+                if (auto it = std::find_if(params.cbegin(), params.cend(), 
+                    [&key](const command::ParamView& data) {
+                        return data.key_ == key; 
+                    }); it == params.cend()
+                ) { // add param to param list if it's not already provided by user
+                    params.push_back(command::ParamView{ 
+                        std::string_view{ k }, std::string_view{ v } });
+                }
+            }
+        }       
+
+        Console::Write("[twitch-debug] process possible command:", chatCommand, '\n');
+        // skipped `kCommandSign`
+        if (auto handle = translator_.GetHandle(chatCommand); handle) {
+            // username (nick) has to be between (! ... @)
+            auto user = ::ExtractBetween(message.prefix_, '!', '@');
+            assert(!user.empty() && "wrong understanding of IRC format");
+            // skipped channel prefix: #
+            auto twitchChannel { ::ShiftView(ircParams[kChannel], 1) };
+
+            command::Args commandParams { 
+                command::ParamView { "channel", twitchChannel },
+                command::ParamView { "user", user } };
+
+            for (auto&& param: params) {
+                commandParams.push_back(param);
+            }
+
+            std::stringstream ss;
+            for (auto&& [k, v]: params) ss << k << " " << v << ' '; 
+            Console::Write("[twitch] params:", ss.str(), '\n');
+            
+            std::invoke(*handle, commandParams);
+        }
+    }
+}
+
+void IrcShard::HandleResponse(net::irc::Message message) {
+    using IrcCommands = net::irc::IrcCommands;
+
+    { // Debug:
+        std::string raw;
+        for (auto&& [key, val]: message.tags_) raw += key + "=" + val + ";";
+        raw += " prefix: " + message.prefix_ 
+            + "; command: " + message.command_ 
+            + "; params (" + std::to_string(message.params_.size()) + "):";
+        for (auto& p: message.params_) raw += " " + p;
+        Console::Write("[twitch] read:", raw, '\n');
+    }
+
+    constexpr IrcCommands ircCmds;
+
+    const auto ircCmdKind = ircCmds.Get(message.command_);
+    if (!ircCmdKind) return;
+
+    switch (*ircCmdKind) {
+        case IrcCommands::kPrivMsg: {
+            HandlePrivateMessage(message);
+        } break;
+        case IrcCommands::kPing: {
+            if (auto handle = translator_.GetHandle("ping"); handle) {
+                std::invoke(*handle, Translator::Params{});
+            }
+        } break;
+        default: assert(false);
+    }
+}
+// ===================== INVOKER =================== //
+
+IrcShard::Invoker::Invoker(IrcShard *shard) 
+    : shard_ { shard } 
+{
+    assert(shard);
+}
+
+
+void IrcShard::Invoker::Execute(command::Help) {
+    assert(false && "TODO: not implemented");
+}
+
+void IrcShard::Invoker::Execute(command::Ping cmd) {
+    assert(shard_ && "Cannot be null");
+    if (!shard_->irc_) {
+        Console::Write("[twitch] ping: irc connection is not established\n");
+    }
+    else {
+        auto pingRequest = request::twitch::Ping{cmd.channel_}.Build();
+        shard_->irc_->ScheduleWrite(std::move(pingRequest), []() {
+            Console::Write("[twitch] send pong request\n");
+        });
+    }
+}
+
+void IrcShard::Invoker::Execute(command::Pong) {
+    assert(shard_ && "Cannot be null");
+    // TODO: still need to handle the case 
+    // when `irc_` is alive but failed [re-]connect!
+    if (!shard_->irc_) {
+        Console::Write("[twitch] pong: irc connection is not established\n");
+    }
+    else {
+        auto pongRequest = request::twitch::Pong{}.Build();
+        shard_->irc_->ScheduleWrite(std::move(pongRequest), []() {
+            Console::Write("[twitch] send pong request\n");
+        });
+    }
+}
+
+void IrcShard::Invoker::Execute(command::Validate) {
+    constexpr std::string_view kHost { "id.twitch.tv" };
+    constexpr std::string_view kService { "https" };
+    const size_t kId { 0 };
+
+    assert(shard_ && "Cannot be null");
+    assert(shard_->service_ && "Cannot be null");
+
+    auto connection = std::make_shared<HttpConnection>(
+        shard_->context_, shard_->ssl_, kHost, kService, kId
+    );
+
+    const Config::Identity kIdentity { "twitch" };
+    const Config *config = shard_->service_->GetConfig();
+    const auto secret = config->GetSecret(kIdentity);
+    if (!secret) {
+        throw std::runtime_error("Fail to create config");
+    }
+
+    auto weak = utils::WeakFrom<HttpConnection>(connection);
+    auto connect = [connection](Chain::Callback cb) {
+        connection->Connect(std::move(cb));
+    };
+
+    auto request = request::twitch::Validation{ secret->token_ }.Build();
+    auto write = [connection, req = std::move(request)](Chain::Callback cb) {
+        connection->ScheduleWrite(std::move(req), std::move(cb));
+    };
+    
+    auto read = [connection](Chain::Callback cb) {
+        connection->Read(std::move(cb));
+    };
+    
+    auto readCallback = [weak]() {
+        auto shared = weak.lock();
+        const auto [head, body] = shared->AcquireResponse();
+        if (head.statusCode_ == 200) {
+            rapidjson::Document json; 
+            json.Parse(body.data(), body.size());
+            auto login = json["login"].GetString();
+            auto expiration = json["expires_in"].GetUint64();
+            Console::Write("[twitch] validation success. Login:", login
+                , "Expire in:", expiration, '\n');
+        }
+        else {
+            Console::Write("[ERROR] [twitch] validation failed. Status:"
+                , head.statusCode_, head.reasonPhrase_
+                , '\n', body, '\n'
+            );
+        }
+    };
+
+    auto chain = std::make_shared<Chain>(shard_->context_);
+    (*chain).Add(std::move(connect))
+        .Add(std::move(write))
+        .Add(std::move(read), std::move(readCallback))
+        .Execute();
+}
+
+void IrcShard::Invoker::Execute(command::Shutdown) {
+    assert(false && "TODO: not implemented");    
+}
+
+void IrcShard::Invoker::Execute(command::Join cmd) {
+    assert(shard_ && "Cannot be null");
+    // TODO: still need to handle the case 
+    // when `irc_` is alive but failed [re-]connect!
+    if (!shard_->irc_) {
+        Console::Write("[twitch] join: irc connection is not established\n");
+    }
+    else {
+        auto join = request::twitch::Join{cmd.channel_}.Build();
+        shard_->irc_->ScheduleWrite(std::move(join), []() {
+            Console::Write("[twitch] send join channel request\n");
+        });
+    }
+}
+
+void IrcShard::Invoker::Execute(command::Chat cmd) {
+    assert(shard_ && "Cannot be null");
+    // TODO: still need to handle the case 
+    // when `irc_` is alive but failed [re-]connect!
+    if (!shard_->irc_) {
+        Console::Write("[twitch] chat: irc connection is not established\n");
+    }
+    else {
+        auto chat = request::twitch::Chat{cmd.channel_, cmd.message_}.Build();
+        Console::Write("[twitch] trying to send message:"
+            , chat.substr(0, chat.size() - 2), "\n");
+        shard_->irc_->ScheduleWrite(std::move(chat), []() {
+            Console::Write("[twitch] sent message to channel\n");
+        });
+    }
+}
+
+void IrcShard::Invoker::Execute(command::Leave cmd) {
+    assert(shard_ && "Cannot be null");
+    // TODO: still need to handle the case 
+    // when `irc_` is alive but failed [re-]connect!
+    if (!shard_->irc_) {
+        Console::Write("[twitch] leave: irc connection is not established\n");
+    }
+    else {
+        auto leave = request::twitch::Leave{cmd.channel_}.Build();
+        shard_->irc_->ScheduleWrite(std::move(leave), []() {
+            Console::Write("[twitch] send part channel request\n");
+        });
+    }
+}
+
+void IrcShard::Invoker::Execute(command::Login cmd) {
+    assert(shard_ && "Cannot be null");
+    // TODO: still need to handle the case 
+    // when all attempt to reconnect failed!
+    if (!shard_->irc_) {
+        Console::Write("[twitch] login: irc connection is not established\n");
+    }
+
+    auto request = request::twitch::IrcAuth{cmd.token_, cmd.user_}.Build();
+    auto irc = shard_->irc_.get();
+    auto readCallback = [irc, shard = shard_](){
+        shard->HandleResponse(irc->AcquireResponse());
+    };
+
+    auto connect = [irc](Chain::Callback cb) {
+        irc->Connect(std::move(cb));
+    };
+    auto write = [irc, request = std::move(request)](Chain::Callback cb) {
+        irc->ScheduleWrite(std::move(request), std::move(cb));
+    };
+    auto read = [irc](Chain::Callback cb){
+        irc->Read(std::move(cb));
+    };
+
+    auto chain = std::make_shared<Chain>(shard_->context_);
+    (*chain).Add(std::move(connect))
+        .Add(std::move(write))
+        .Add(std::move(read), std::move(readCallback))
+        .Execute();
+}
+
+void IrcShard::Invoker::Execute(command::RealmStatus cmd) {
+    assert(shard_ && "Cannot be null");
+    assert(shard_->irc_ && "Cannot be null");
+
+    Console::Write("[twitch] execute realm-status command:"
+        , cmd.channel_, cmd.user_, '\n');
+    command::RawCommand raw { "realm-status", { 
+        command::ParamData { "channel", std::move(cmd.channel_) }
+        , { "user", std::move(cmd.user_) } }
+    };
+
+    if (shard_->commands_->TryPush(std::move(raw))) {
+        Console::Write("[twitch] push `RealmStatus` to queue\n");
+    }
+    else {
+        Console::Write("[twitch] failed to push "
+            "`RealmStatus` to queue is full\n");
+    }
+}
+
+void IrcShard::Invoker::Execute(command::Arena cmd) {
+    assert(shard_ && "Cannot be null");
+    assert(shard_->irc_ && "Cannot be null");
+
+    Console::Write("[twitch] execute arena command:"
+        , cmd.channel_, cmd.user_,  cmd.player_, '\n');
+
+    command::RawCommand raw { "arena", { 
+        command::ParamData { "channel", std::move(cmd.channel_) }
+        , { "user", std::move(cmd.user_) } 
+        , { "player", std::move(cmd.player_) } }
+    };
+
+    if (shard_->commands_->TryPush(std::move(raw))) {
+        Console::Write("[twitch] push `arena` to queue\n");
+    }
+    else {
+        Console::Write("[twitch] failed to push `arena` to queue is full\n");
+    }
+}
+
+} // namespace service::twitch

--- a/src/IrcShard.cpp
+++ b/src/IrcShard.cpp
@@ -120,8 +120,8 @@ IrcShard::IrcShard(Twitch *service
     }
     , service_ { service }
     , commands_ { rawCommands }
-    , aliases_ { aliases }
     , translator_ {}
+    , aliases_ { aliases }
     , context_ { context }
     , ssl_ { ssl }
     , invoker_ { std::make_unique<Invoker>(this) }
@@ -348,7 +348,7 @@ void IrcShard::Invoker::Execute(command::Validate) {
     auto read = [connection](Chain::Callback cb) {
         connection->Read(std::move(cb));
     };
-    
+
     auto weak = utils::WeakFrom<HttpConnection>(connection);    
     auto readCallback = [weak]() {
         auto shared = weak.lock();

--- a/src/IrcShard.cpp
+++ b/src/IrcShard.cpp
@@ -237,6 +237,10 @@ void IrcShard::HandlePrivateMessage(net::irc::Message& message) {
             for (auto&& [k, v]: params) ss << k << " " << v << ' '; 
             Console::Write("[twitch] params:", ss.str(), '\n');
             
+            // This is a shortcut: 
+            // avoiding global queue (processed in App type)
+            // I call Invoker::Execute when connection has 
+            // just read incoming message
             std::invoke(*handle, commandParams);
         }
     }
@@ -266,6 +270,10 @@ void IrcShard::HandleResponse(net::irc::Message message) {
         } break;
         case IrcCommands::kPing: {
             if (auto handle = translator_.GetHandle("ping"); handle) {
+                // This is a shortcut: 
+                // avoiding global queue (processed in App type)
+                // I call Invoker::Execute when connection has 
+                // just read incoming message
                 std::invoke(*handle, Translator::Params{});
             }
         } break;

--- a/src/IrcShard.hpp
+++ b/src/IrcShard.hpp
@@ -8,8 +8,8 @@
 #include <string>
 #include <vector>
 #include <array>
-#include <unordered_map>
 #include <memory>
+#include <mutex>
 
 #include "Command.hpp"
 #include "Translator.hpp"
@@ -23,30 +23,83 @@ namespace service::twitch {
 using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
 using Seconds = std::chrono::seconds;
 
+/**
+ * Usage:
+ * 1. Use bucket to acquire ticket for irc connection for 
+ * command execution (if bucket is not empty)
+ * 2. Ticket must be passed to `onWrite` callback in execution chain 
+ * and explicitly called Ticket::Release there.
+ * 
+ * Note: only MessageBucket::refillAmount_ tickets can exist at once.
+ * It makes impossible to use `refillAmount_` tickets right before refilling
+ * and `refillAmount_` right after(i.e., legaly use 2X tickets in short 
+ * amount of time <= `refillRate_`) in short timelapse, 
+ * however it prevents usage more than `refillAmount_` tickets at once.
+ *
+ * As answering to EVERY request of the users deemed not very important
+ * I don't enqueue requests which can't get ticket due to rate-limit
+ * I just abandon them.
+ *
+ * TODO: maybe queue message which will notify that some message were ignored
+ * and advice to repeat it again
+ */
 class MessageBucket final {
 public:
+    class Ticket final {
+    public:
+
+        Ticket(MessageBucket* bucket);
+        
+        void Release() noexcept;
+
+    private:
+        // Assume, bucket can't be destroyed 
+        // while IrcShard(and IrcConnection) exists
+        MessageBucket* const bucket_ { nullptr };
+        bool released_ { false };
+    };
+
     MessageBucket(std::uint16_t amount, Seconds rate);
 
-    // Actually, it's not precision approach 
-    // cuz we lose some tickets(opportunity to write)
-    // but I can avoid using timer
-    bool TryUse();
+    // Q: Why Not Optional?
+    // A: Used shared_ptr instead of optional with move semantic 
+    // because capturing move-only object will make move-only lambda 
+    // so I won't be able to create callback of type `std::function<void()>`
+    // which has requirement Copy[Assignable|Constructable]
+    std::shared_ptr<Ticket> TryAcquire();
+
+    void Release();
 
 private:
+    
+    void TryRefill();
+
     // `bucket size`
     // differ for user mode and moderator mode
     const std::uint16_t refillAmount_;
     // amount of available messages for IRC connection
     std::uint16_t available_;
+    // already consumed during the last refill
+    std::uint16_t consumed_;
     // shows how much time needs to pass to fill the bucket
     // Note: differ for user mode and moderator mode
     const Seconds refillRate_;
     TimePoint lastRefillTime_;
+
+    mutable std::mutex mutex_;
 };
 
-// namespace ssl = boost::asio::ssl;
-// using boost::asio::ip::tcp;
-
+/**
+ * Thread-safety concerns:
+ *  IrcShard is being touched (after being constructed) 
+ *  only by `Twitch::ResetWork` and `Twitch::Execute`
+ *  so these are narrow places.
+ * 
+ * 1. service::Twitch's destructor returns after all work which is being posted to `io_context`
+ *  is done.
+ * 2. After completion of all work in `io_context` the `IrcConnection` will exist only in 
+ * `IrcShard` (ONLY 1 strong reference). See `assert` in `~IrcShard()`
+ */
 class IrcShard final {
 public:
     using SharedIO = std::shared_ptr<boost::asio::io_context>;
@@ -58,6 +111,11 @@ public:
         , SharedIO context
         , SharedSSL ssl);
 
+    // ASSUME: `irc_->ScheduleShutdown()` has already been called, 
+    // i.e., IrcShard::Reset() had been already invoked before the ~IrcShard
+    // 
+    // TODO: Reset may no be called if excption is thrown. 
+    //       Find and resolve such dangerous places.
     ~IrcShard();
 
     void Reset();
@@ -74,7 +132,7 @@ private:
     void HandlePrivateMessage(net::irc::Message& message);
 
 private:
-    // IRC limits: https://dev.twitch.tv/docs/irc/guide
+    // Twitch's IRC limits: https://dev.twitch.tv/docs/irc/guide
     static constexpr std::uint16_t kRefillAmount{ 20 };
     static constexpr Seconds kGeneralRefillRate{ 10 };
     static constexpr Seconds kChannelRefillRate{ 30 };
@@ -84,27 +142,34 @@ private:
     };
 
     enum Bucket: uint16_t { 
-        kGeneral, // auth + join
-        kChannel, // privmsg + cap [sending commands or messages to channels]
+        kGeneral, // PASS, JOIN
+        kChannel, // PRIVMSG
         kCount
     };
-    const std::array<MessageBucket, Bucket::kCount> buckets_;
-    std::unordered_map<std::string_view, Bucket> bucketByCommand_;
+    std::array<MessageBucket, Bucket::kCount> buckets_;
     
-    // stuff from the twitch context 
+    // Stuff from the twitch context;
     // required for creating HTTP connection
     Twitch *const service_ { nullptr };
     command::Queue *const commands_ { nullptr };
     Translator translator_;
-    // keep bindings of [aliases] to [commands with parameters]
+    // Keep bindings of [aliases] to [commands with parameters]
     command::AliasTable *const aliases_ { nullptr };
 
-    // connection
+    // Contexts for connection's creation
     SharedIO context_;
     SharedSSL ssl_;
+
+    // Thread-safety:
+    // - `shared_ptr` - used only with const methods so no data race here.
+    //   As long as `irc_` is not reseted manually no data race will occur.
+    // - `IrcConnection` object - it cannot live more than `IrcShard` because 
+    //  the only thing that can prolong it's life is `context_` 
+    //  whereas `context_` should complete all work by the time the IrcShard 
+    //  will be destroyed.
     std::shared_ptr<IrcConnection> irc_;
 
-    // list of connected channels
+    // List of connected channels
     std::vector<Channel> channels_;
 
     class Invoker;
@@ -116,11 +181,11 @@ public:
     Invoker(IrcShard *shard);
 
     void Execute(command::Help);
+    void Execute(command::Ping);
+    void Execute(command::Pong);
     void Execute(command::Shutdown);
     void Execute(command::Validate);
     void Execute(command::Login);
-    void Execute(command::Ping);
-    void Execute(command::Pong);
     void Execute(command::Join);
     void Execute(command::Leave);
     void Execute(command::Chat);

--- a/src/IrcShard.hpp
+++ b/src/IrcShard.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <array>
+#include <unordered_map>
+#include <memory>
+
+#include "Command.hpp"
+#include "Translator.hpp"
+#include "Alias.hpp"
+#include "Response.hpp" // net::irc::Message
+
+class IrcConnection;
+
+namespace service::twitch {
+
+using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+using Seconds = std::chrono::seconds;
+
+class MessageBucket final {
+public:
+    MessageBucket(std::uint16_t amount, Seconds rate);
+
+    // Actually, it's not precision approach 
+    // cuz we lose some tickets(opportunity to write)
+    // but I can avoid using timer
+    bool TryUse();
+
+private:
+    // `bucket size`
+    // differ for user mode and moderator mode
+    const std::uint16_t refillAmount_;
+    // amount of available messages for IRC connection
+    std::uint16_t available_;
+    // shows how much time needs to pass to fill the bucket
+    // Note: differ for user mode and moderator mode
+    const Seconds refillRate_;
+    TimePoint lastRefillTime_;
+};
+
+// namespace ssl = boost::asio::ssl;
+// using boost::asio::ip::tcp;
+
+class IrcShard final {
+public:
+    using SharedIO = std::shared_ptr<boost::asio::io_context>;
+    using SharedSSL = std::shared_ptr<boost::asio::ssl::context>;
+
+    IrcShard(Twitch *service
+        , command::Queue *commands
+        , command::AliasTable *alias
+        , SharedIO context
+        , SharedSSL ssl);
+
+    ~IrcShard();
+
+    void Reset();
+
+    template<typename Command,
+        typename Enable = std::enable_if_t<command::details::is_twitch_api_v<Command>>
+    >
+    void Execute(Command&& cmd);
+
+private:
+
+    void HandleResponse(net::irc::Message message);
+
+    void HandlePrivateMessage(net::irc::Message& message);
+
+private:
+    // IRC limits: https://dev.twitch.tv/docs/irc/guide
+    static constexpr std::uint16_t kRefillAmount{ 20 };
+    static constexpr Seconds kGeneralRefillRate{ 10 };
+    static constexpr Seconds kChannelRefillRate{ 30 };
+    
+    struct Channel {
+        std::string name; // unique
+    };
+
+    enum Bucket: uint16_t { 
+        kGeneral, // auth + join
+        kChannel, // privmsg + cap [sending commands or messages to channels]
+        kCount
+    };
+    const std::array<MessageBucket, Bucket::kCount> buckets_;
+    std::unordered_map<std::string_view, Bucket> bucketByCommand_;
+    
+    // stuff from the twitch context 
+    // required for creating HTTP connection
+    Twitch *const service_ { nullptr };
+    command::Queue *const commands_ { nullptr };
+    Translator translator_;
+    // keep bindings of [aliases] to [commands with parameters]
+    command::AliasTable *const aliases_ { nullptr };
+
+    // connection
+    SharedIO context_;
+    SharedSSL ssl_;
+    std::shared_ptr<IrcConnection> irc_;
+
+    // list of connected channels
+    std::vector<Channel> channels_;
+
+    class Invoker;
+    std::unique_ptr<Invoker> invoker_;
+};
+
+class IrcShard::Invoker {
+public:
+    Invoker(IrcShard *shard);
+
+    void Execute(command::Help);
+    void Execute(command::Shutdown);
+    void Execute(command::Validate);
+    void Execute(command::Login);
+    void Execute(command::Ping);
+    void Execute(command::Pong);
+    void Execute(command::Join);
+    void Execute(command::Leave);
+    void Execute(command::Chat);
+    void Execute(command::RealmStatus);
+    void Execute(command::Arena);
+
+private:
+    IrcShard * const shard_ { nullptr };
+};
+
+
+template<typename Command, typename Enable>
+inline void IrcShard::Execute(Command&& cmd) {
+    invoker_->Execute(std::forward<Command>(cmd));
+}
+
+} // namespace service::twitch

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -48,6 +48,7 @@ public:
             default: break;
         }
         ((os_ << " " << std::forward<Args>(args)), ...);
+        os_.flush();
     }
 
 private:

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -69,6 +69,15 @@ std::string Validation::Build() const {
     return (boost::format(requestTemplate) % token_).str();
 }
 
+/*
+< PING <channel>
+> :tmi.twitch.tv PONG tmi.twitch.tv :<channel>
+*/
+std::string Ping::Build() const {
+    using namespace std::literals;
+    return "PING "s + channel_ + "\r\n"s;
+}
+
 std::string Pong::Build() const {
     return "PONG :tmi.twitch.tv\r\n";
 }

--- a/src/Request.hpp
+++ b/src/Request.hpp
@@ -47,6 +47,18 @@ namespace twitch {
         std::string user_;
     };
 
+    class Ping : public Query {
+    public:
+
+        Ping(const std::string& channel) 
+            : channel_ { channel } {}
+
+        std::string Build() const override;
+        
+    private:
+        std::string channel_;
+    };
+
     class Pong : public Query {
     public:
 

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -44,10 +44,15 @@ Header ParseHeader(std::string_view src) {
     result.bodyLength_ = std::string_view::npos;
     // extract FIELDS
     for (size_t start = statusEnd, finish = src.find_first_of(kFieldDelimiter.data(), statusEnd); 
-        finish != std::string::npos && start != finish;
+        start < src.size();
         finish = src.find_first_of(kFieldDelimiter.data(), start)
     ) {
-        std::string_view raw { src.data() + start, finish - start };
+        if (finish == std::string_view::npos) {
+            // reach end of the string
+            finish = src.size();
+        }
+
+        std::string_view raw {src.data() + start, finish - start };
         const auto split = raw.find_first_of(':');
         assert(split != std::string_view::npos && "Expected format: <key>:<value> not found");
 

--- a/src/Translator.hpp
+++ b/src/Translator.hpp
@@ -24,7 +24,7 @@ public:
         table_.insert(commandList);
     }
 
-    std::optional<Handle> GetHandle(std::string_view command) const noexcept {
+    std::optional<Handle> GetHandle(std::string_view command) const {
         if (auto it = table_.find(command); it != table_.end()) {
             return std::make_optional<Handle>(it->second);
         }
@@ -32,7 +32,7 @@ public:
     }
 
     template<typename Command, typename Service>
-    static Handle CreateHandle(Service& ctx) noexcept {
+    static Handle CreateHandle(Service& ctx) {
         return [&ctx](const Params& params) mutable {
             Execute(Command::Create(ctx, params), ctx);
         };

--- a/src/Twitch.cpp
+++ b/src/Twitch.cpp
@@ -1,74 +1,37 @@
 #include "Twitch.hpp"
 #include "Console.hpp"
-#include "Connection.hpp"
-#include "Request.hpp"
-#include "Command.hpp"
-#include "Utility.hpp"
-#include "Alias.hpp"
-#include "Chain.hpp"
-
-#include "rapidjson/document.h"
+#include "IrcShard.hpp"
 
 #include <algorithm>
 #include <stdexcept>
-#include <cctype>
-#include <sstream>
-
-namespace {
-    std::string ExtractBetween(const std::string& src, char left, char right) {
-        const auto leftDelim = src.find(left);
-        const auto rightDelim = src.find(right, leftDelim);
-        if (leftDelim == std::string::npos || rightDelim == std::string::npos) {
-            return {};
-        } 
-        else {
-            return { src.substr(leftDelim + 1, rightDelim - leftDelim - 1) };
-        }
-    }
-
-    inline std::string_view ShiftView(const std::string& src, size_t shift) noexcept {
-        assert(shift < src.size());
-        return { src.data() + shift, src.size() - shift};
-    }
-
-}
 
 namespace service {
 
 Twitch::Twitch(const Config *config
-    , Container * outbox
-    , command::AliasTable * aliases
+    , command::Queue *outbox
+    , command::AliasTable *aliases
 ) 
     : context_ { std::make_shared<boost::asio::io_context>() }
     , work_ { context_->get_executor() }
     , ssl_ { std::make_shared<ssl::context>(ssl::context::method::sslv23_client) }
-    , translator_ {}
     , config_ { config }
-    , outbox_ { outbox }
-    , aliases_ { aliases }
-    , invoker_ { std::make_unique<Invoker>(this) }
 {
     assert(config_ && "Config is NULL");
-    assert(outbox_ && "Queue is NULL");
+    assert(outbox && "Queue is NULL");
+    assert(aliases && "AliasTable is NULL");
     /**
      * [Amazon CA](https://www.amazontrust.com/repository/)
      * TODO: read this path from secret + with some chiper
     */
-    const char * const kVerifyFilePath = "crt/StarfieldServicesRootCA.crt.pem";
+    const char * const kVerifyFilePath { "crt/StarfieldServicesRootCA.crt.pem" };
     boost::system::error_code error;
     ssl_->load_verify_file(kVerifyFilePath, error);
     if (error) {
         Console::Write("[ERROR]: ", error.message(), '\n');
     }
 
-    using namespace std::literals::string_view_literals;
-    std::initializer_list<Translator::Pair> commands {
-        { "help"sv,         Translator::CreateHandle<command::Help>(*this) },
-        { "ping"sv,         Translator::CreateHandle<command::Pong>(*this) },
-        { "arena"sv,        Translator::CreateHandle<command::Arena>(*this) },
-        { "realm-status"sv, Translator::CreateHandle<command::RealmStatus>(*this) }
-    };
-    translator_.Insert(commands);
+    shard_ = std::make_unique<twitch::IrcShard>(
+        this, outbox, aliases, context_, ssl_);
 }
 
 Twitch::~Twitch() {
@@ -78,9 +41,8 @@ Twitch::~Twitch() {
 
 void Twitch::ResetWork() {
     work_.reset();
-    if (irc_) {
-        irc_->ScheduleShutdown();
-        irc_.reset();
+    if (shard_) {
+        shard_->Reset();
     }
     // don't stop context to let it finish all jobs 
     // and shutdown connections gracefully
@@ -88,9 +50,10 @@ void Twitch::ResetWork() {
 
 void Twitch::Run() {
     for (size_t i = 0; i < kThreads; i++) {
-        threads_.emplace_back([this](){
+        threads_.emplace_back([this] {
             for (;;) {
                 try {
+                    // TODO: clarify is there any data race around `shared_ptr`?
                     context_->run();
                     break;
                 }
@@ -100,338 +63,6 @@ void Twitch::Run() {
                 }
             }
         });
-    }
-}
-
-void Twitch::HandlePrivateMessage(net::irc::Message& message) {
-    enum { kChannel, kMessage, kRequiredFields };
-    static_assert(kMessage == 1, "According to IRC format message "
-        "for PRIVMSG command is always second parameter"
-        "(numeration starting with 0)");
-    
-    // user command, not IRC command
-    enum Sign : char { kChannelSign = '#', kCommandSign = '!'};
-    auto& ircParams { message.params_ };
-
-    // is user-defined command
-    if (ircParams.size() == kRequiredFields
-        && ircParams[kChannel].front() == kChannelSign
-        && ircParams[kMessage].front() == kCommandSign
-    ) {
-        // chat message is an input from the user in twitch chat
-        auto& chatMessage { ircParams[kMessage] };
-        std::transform(chatMessage.cbegin()
-            , chatMessage.cend()
-            , chatMessage.begin()
-            , [](unsigned char c) { return std::tolower(c); }
-        );
-
-        std::string_view unprocessed { chatMessage };
-        size_t chatCommandEnd = unprocessed.find_first_of(' ');
-        if (chatCommandEnd == std::string_view::npos) {
-            chatCommandEnd = unprocessed.size();
-        }
-        // here we're still not sure whether it's a command or just a coincidence
-        std::string_view chatCommand { unprocessed.data() + 1, chatCommandEnd - 1 };
-        unprocessed.remove_prefix(chatCommandEnd + 1);
-        // divide message to tokens (maybe parameters for the chat command)
-        auto params = command::ExtractArgs(unprocessed, ' ');
-
-        assert(aliases_);
-        // Substitute alias with command and required params if it's alias
-        auto referred = aliases_->GetCommand(chatCommand);
-        if (referred) { 
-            Console::Write("[twitch] used alias "
-                , chatCommand, "refers to "
-                , referred->command, '\n');
-            chatCommand = referred->command;
-            for (const auto& [k, v]: referred->params) {
-                const auto& key = k;
-                if (auto it = std::find_if(params.cbegin(), params.cend(), 
-                    [&key](const command::ParamView& data) {
-                        return data.key_ == key; 
-                    }); it == params.cend()
-                ) { // add param to param list if it's not already provided by user
-                    params.push_back(command::ParamView{ 
-                        std::string_view{ k }, std::string_view{ v } });
-                }
-            }
-        }       
-
-        Console::Write("[twitch-debug] process possible command:", chatCommand, '\n');
-        // skipped `kCommandSign`
-        if (auto handle = translator_.GetHandle(chatCommand); handle) {
-            // username (nick) has to be between (! ... @)
-            auto user = ::ExtractBetween(message.prefix_, '!', '@');
-            assert(!user.empty() && "wrong understanding of IRC format");
-            // skipped channel prefix: #
-            auto twitchChannel { ::ShiftView(ircParams[kChannel], 1) };
-
-            command::Args commandParams { 
-                command::ParamView { "channel", twitchChannel },
-                command::ParamView { "user", user } };
-
-            for (auto&& param: params) {
-                commandParams.push_back(param);
-            }
-
-            std::stringstream ss;
-            for (auto&& [k, v]: params) ss << k << " " << v << ' '; 
-            Console::Write("[twitch] params:", ss.str(), '\n');
-            
-            std::invoke(*handle, commandParams);
-        }
-    }
-}
-
-void Twitch::HandleResponse(net::irc::Message message) {
-    using IrcCommands = net::irc::IrcCommands;
-
-    constexpr IrcCommands ircCmds;
-
-    { // Debug:
-        std::string raw;
-        for (auto&& [key, val]: message.tags_) raw += key + "=" + val + ";";
-        raw += " prefix: " + message.prefix_ 
-            + "; command: " + message.command_ 
-            + "; params (" + std::to_string(message.params_.size()) + "):";
-        for (auto& p: message.params_) raw += " " + p;
-        Console::Write("[twitch] read:", raw, '\n');
-    }
-
-    const auto ircCmdKind = ircCmds.Get(message.command_);
-    if (!ircCmdKind) return;
-
-    switch (*ircCmdKind) {
-        case IrcCommands::kPrivMsg: {
-            HandlePrivateMessage(message);
-        } break;
-        case IrcCommands::kPing: {
-            if (auto handle = translator_.GetHandle("ping"); handle) {
-                std::invoke(*handle, Translator::Params{});
-            }
-        } break;
-        default: assert(false);
-    }
-}
-
-void Twitch::Invoker::Execute(command::Help) {
-    assert(false && "TODO: not implemented");
-}
-
-void Twitch::Invoker::Execute(command::Ping cmd) {
-    assert(twitch_ && "Cannot be null");
-    if (!twitch_->irc_) {
-        Console::Write("[twitch] ping: irc connection is not established\n");
-    }
-    else {
-        auto pingRequest = request::twitch::Ping{cmd.channel_}.Build();
-        twitch_->irc_->ScheduleWrite(std::move(pingRequest), []() {
-            Console::Write("[twitch] send pong request\n");
-        });
-    }
-}
-
-void Twitch::Invoker::Execute(command::Pong) {
-    assert(twitch_ && "Cannot be null");
-    // TODO: still need to handle the case 
-    // when `irc_` is alive but failed [re-]connect!
-    if (!twitch_->irc_) {
-        Console::Write("[twitch] pong: irc connection is not established\n");
-    }
-    else {
-        auto pongRequest = request::twitch::Pong{}.Build();
-        twitch_->irc_->ScheduleWrite(std::move(pongRequest), []() {
-            Console::Write("[twitch] send pong request\n");
-        });
-    }
-}
-
-void Twitch::Invoker::Execute(command::Validate) {
-    constexpr std::string_view kHost { "id.twitch.tv" };
-    constexpr std::string_view kService { "https" };
-    const size_t kId { 0 };
-
-    assert(twitch_ && "Cannot be null");
-
-    auto connection = std::make_shared<HttpConnection>(
-        twitch_->context_, twitch_->ssl_, kHost, kService, kId
-    );
-
-    const Config::Identity kIdentity { "twitch" };
-    const auto secret = twitch_->GetConfig()->GetSecret(kIdentity);
-    if (!secret) {
-        throw std::runtime_error("Fail to create config");
-    }
-
-    auto weak = utils::WeakFrom<HttpConnection>(connection);
-    auto connect = [connection](Chain::Callback cb) {
-        connection->Connect(std::move(cb));
-    };
-
-    auto request = request::twitch::Validation{ secret->token_ }.Build();
-    auto write = [connection, req = std::move(request)](Chain::Callback cb) {
-        connection->ScheduleWrite(std::move(req), std::move(cb));
-    };
-    
-    auto read = [connection](Chain::Callback cb) {
-        connection->Read(std::move(cb));
-    };
-    
-    auto readCallback = [weak]() {
-        auto shared = weak.lock();
-        const auto [head, body] = shared->AcquireResponse();
-        if (head.statusCode_ == 200) {
-            rapidjson::Document json; 
-            json.Parse(body.data(), body.size());
-            auto login = json["login"].GetString();
-            auto expiration = json["expires_in"].GetUint64();
-            Console::Write("[twitch] validation success. Login:", login
-                , "Expire in:", expiration, '\n');
-        }
-        else {
-            Console::Write("[ERROR] [twitch] validation failed. Status:"
-                , head.statusCode_, head.reasonPhrase_
-                , '\n', body, '\n'
-            );
-        }
-    };
-
-    auto chain = std::make_shared<Chain>(twitch_->context_);
-    (*chain).Add(std::move(connect))
-        .Add(std::move(write))
-        .Add(std::move(read), std::move(readCallback))
-        .Execute();
-}
-
-void Twitch::Invoker::Execute(command::Shutdown) {
-    assert(false && "TODO: not implemented");    
-}
-
-void Twitch::Invoker::Execute(command::Join cmd) {
-    assert(twitch_ && "Cannot be null");
-    // TODO: still need to handle the case 
-    // when `irc_` is alive but failed [re-]connect!
-    if (!twitch_->irc_) {
-        Console::Write("[twitch] join: irc connection is not established\n");
-    }
-    else {
-        auto join = request::twitch::Join{cmd.channel_}.Build();
-        twitch_->irc_->ScheduleWrite(std::move(join), []() {
-            Console::Write("[twitch] send join channel request\n");
-        });
-    }
-}
-
-void Twitch::Invoker::Execute(command::Chat cmd) {
-    assert(twitch_ && "Cannot be null");
-    // TODO: still need to handle the case 
-    // when `irc_` is alive but failed [re-]connect!
-    if (!twitch_->irc_) {
-        Console::Write("[twitch] chat: irc connection is not established\n");
-    }
-    else {
-        auto chat = request::twitch::Chat{cmd.channel_, cmd.message_}.Build();
-        Console::Write("[twitch] trying to send message:"
-            , chat.substr(0, chat.size() - 2), "\n");
-        twitch_->irc_->ScheduleWrite(std::move(chat), []() {
-            Console::Write("[twitch] sent message to channel\n");
-        });
-    }
-}
-
-void Twitch::Invoker::Execute(command::Leave cmd) {
-    assert(twitch_ && "Cannot be null");
-    // TODO: still need to handle the case 
-    // when `irc_` is alive but failed [re-]connect!
-    if (!twitch_->irc_) {
-        Console::Write("[twitch] leave: irc connection is not established\n");
-    }
-    else {
-        auto leave = request::twitch::Leave{cmd.channel_}.Build();
-        twitch_->irc_->ScheduleWrite(std::move(leave), []() {
-            Console::Write("[twitch] send part channel request\n");
-        });
-    }
-}
-
-void Twitch::Invoker::Execute(command::Login cmd) {
-    assert(twitch_ && "Cannot be null");
-    // TODO: still need to handle the case 
-    // when all attempt to reconnect failed!
-    if (twitch_->irc_) {
-        Console::Write("[twitch] irc connection is already established\n");
-        return;
-    }
-
-    const size_t id { 0 };
-    twitch_->irc_ = std::make_shared<IrcConnection>(twitch_->context_
-        , twitch_->ssl_
-        , request::twitch::kHost
-        , request::twitch::kService
-        , id
-    );
-
-    auto request = request::twitch::IrcAuth{cmd.token_, cmd.user_}.Build();
-    auto irc = twitch_->irc_.get();
-    auto readCallback = [irc, twitch = twitch_](){
-        twitch->HandleResponse(irc->AcquireResponse());
-    };
-
-    auto connect = [irc](Chain::Callback cb) {
-        irc->Connect(std::move(cb));
-    };
-    auto write = [irc, request = std::move(request)](Chain::Callback cb) {
-        irc->ScheduleWrite(std::move(request), std::move(cb));
-    };
-    auto read = [irc](Chain::Callback cb){
-        irc->Read(std::move(cb));
-    };
-
-    auto chain = std::make_shared<Chain>(twitch_->context_);
-    (*chain).Add(std::move(connect))
-        .Add(std::move(write))
-        .Add(std::move(read), std::move(readCallback))
-        .Execute();
-}
-
-void Twitch::Invoker::Execute(command::RealmStatus cmd) {
-    assert(twitch_ && "Cannot be null");
-    assert(twitch_->irc_ && "Cannot be null");
-
-    Console::Write("[twitch] execute realm-status command:"
-        , cmd.channel_, cmd.user_, '\n');
-    command::RawCommand raw { "realm-status", { 
-        command::ParamData { "channel", std::move(cmd.channel_) }
-        , { "user", std::move(cmd.user_) } }
-    };
-    if (twitch_->outbox_->TryPush(std::move(raw))) {
-        Console::Write("[twitch] push `RealmStatus` to queue\n");
-    }
-    else {
-        Console::Write("[twitch] failed to push "
-            "`RealmStatus` to queue is full\n");
-    }
-}
-
-void Twitch::Invoker::Execute(command::Arena cmd) {
-    assert(twitch_ && "Cannot be null");
-    assert(twitch_->irc_ && "Cannot be null");
-
-    Console::Write("[twitch] execute arena command:"
-        , cmd.channel_, cmd.user_,  cmd.player_, '\n');
-
-    command::RawCommand raw { "arena", { 
-        command::ParamData { "channel", std::move(cmd.channel_) }
-        , { "user", std::move(cmd.user_) } 
-        , { "player", std::move(cmd.player_) } }
-    };
-
-    if (twitch_->outbox_->TryPush(std::move(raw))) {
-        Console::Write("[twitch] push `arena` to queue\n");
-    }
-    else {
-        Console::Write("[twitch] failed to push `arena` to queue is full\n");
     }
 }
 

--- a/src/Twitch.cpp
+++ b/src/Twitch.cpp
@@ -219,6 +219,19 @@ void Twitch::Invoker::Execute(command::Help) {
     assert(false && "TODO: not implemented");
 }
 
+void Twitch::Invoker::Execute(command::Ping cmd) {
+    assert(twitch_ && "Cannot be null");
+    if (!twitch_->irc_) {
+        Console::Write("[twitch] ping: irc connection is not established\n");
+    }
+    else {
+        auto pingRequest = request::twitch::Ping{cmd.channel_}.Build();
+        twitch_->irc_->ScheduleWrite(std::move(pingRequest), []() {
+            Console::Write("[twitch] send pong request\n");
+        });
+    }
+}
+
 void Twitch::Invoker::Execute(command::Pong) {
     assert(twitch_ && "Cannot be null");
     // TODO: still need to handle the case 

--- a/src/Twitch.cpp
+++ b/src/Twitch.cpp
@@ -41,8 +41,8 @@ Twitch::~Twitch() {
 
 void Twitch::ResetWork() {
     assert(shard_);
-    work_.reset();
     shard_->Reset();
+    work_.reset();
     // don't stop context to let it finish all jobs 
     // and shutdown connections gracefully
 }

--- a/src/Twitch.hpp
+++ b/src/Twitch.hpp
@@ -83,6 +83,7 @@ public:
     void Execute(command::Shutdown);
     void Execute(command::Validate);
     void Execute(command::Login);
+    void Execute(command::Ping);
     void Execute(command::Pong);
     void Execute(command::Join);
     void Execute(command::Leave);

--- a/src/Twitch.hpp
+++ b/src/Twitch.hpp
@@ -42,6 +42,7 @@ public:
     >
     void Execute(Command&& cmd);
 
+    // Called only from App::~App
     void ResetWork();
 
     const Config* GetConfig() const noexcept {
@@ -63,7 +64,8 @@ private:
     
     // keep twitch's secret data
     const Config * const config_ { nullptr };
-
+    // It's been seen as readonly unique_ptr by App's worker threads
+    // Note: in call-chains it's only been dereferenced! (readonly access)
     std::unique_ptr<twitch::IrcShard> shard_;
 };
 

--- a/src/Twitch.hpp
+++ b/src/Twitch.hpp
@@ -8,16 +8,14 @@
 #include <vector>
 #include <thread>
 
-#include "Command.hpp"
 #include "Config.hpp"
-#include "Response.hpp"
-#include "Translator.hpp"
-#include "ConcurrentQueue.hpp"
-#include "Environment.hpp"
 #include "Command.hpp"
-#include "Alias.hpp"
+#include "IrcShard.hpp"
 
-class IrcConnection;
+// forward declaration
+namespace command {
+    class AliasTable;
+}
 
 namespace service {
 
@@ -28,9 +26,9 @@ class Twitch
     : public std::enable_shared_from_this<Twitch> 
 {
 public:
-    using Container = CcQueue<command::RawCommand, cst::kQueueCapacity>;
-
-    Twitch(const Config *config, Container * outbox, command::AliasTable * aliases);
+    Twitch(const Config *config
+        , command::Queue *outbox
+        , command::AliasTable *aliases);
     ~Twitch();
     Twitch(const Twitch&) = delete;
     Twitch(Twitch&&) = delete;
@@ -51,13 +49,10 @@ public:
     }
 
 private:
-    void HandleResponse(net::irc::Message message);
-
-    void HandlePrivateMessage(net::irc::Message& message);
-
-    class Invoker;
-
-    using Work = boost::asio::executor_work_guard<boost::asio::io_context::executor_type>;
+    template<class T>
+    using executor_work_guard = boost::asio::executor_work_guard<T>;
+    using executor_type = boost::asio::io_context::executor_type;
+    using Work = executor_work_guard<executor_type>;
 
     static constexpr size_t kThreads { 2 };
     std::vector<std::thread> threads_;
@@ -65,39 +60,16 @@ private:
     std::shared_ptr<boost::asio::io_context> context_;
     Work work_;
     std::shared_ptr<ssl::context> ssl_;
-    std::shared_ptr<IrcConnection> irc_;
-    Translator translator_;
     
+    // keep twitch's secret data
     const Config * const config_ { nullptr };
-    Container * const outbox_ { nullptr };
-    command::AliasTable * const aliases_ { nullptr };
 
-    std::unique_ptr<Invoker> invoker_;
-};
-
-class Twitch::Invoker {
-public:
-    Invoker(Twitch *twitch) : twitch_ { twitch } {}
-
-    void Execute(command::Help);
-    void Execute(command::Shutdown);
-    void Execute(command::Validate);
-    void Execute(command::Login);
-    void Execute(command::Ping);
-    void Execute(command::Pong);
-    void Execute(command::Join);
-    void Execute(command::Leave);
-    void Execute(command::Chat);
-    void Execute(command::RealmStatus);
-    void Execute(command::Arena);
-
-private:
-    Twitch * const twitch_ { nullptr };
+    std::unique_ptr<twitch::IrcShard> shard_;
 };
 
 template<typename Command, typename Enable>
 inline void Twitch::Execute(Command&& cmd) {
-    invoker_->Execute(std::forward<Command>(cmd));
+    shard_->Execute(std::forward<Command>(cmd));
 }
 
 } // namespace service


### PR DESCRIPTION
Added rate limits for **PASS**, **JOIN**, **PRIVMSG** using time window. A smallest message bucket size is choosen because Authority feature is not implemented yet.

According to [Twitch Guide](https://dev.twitch.tv/docs/irc/guide):

> There are limits to the number of IRC commands or messages a developer can send to the server, the number of authentication and joins that can be attempted, and the number of Whispers (i.e. private messages) that can be sent.
> If command and message rate limits are exceeded, an application cannot send chat messages or commands for 30 minutes.

