### PR TITLE
Fix bug with overwritting `OnWrite` callbacks

### DIFF
--- a/src/Blizzard.cpp
+++ b/src/Blizzard.cpp
@@ -383,7 +383,7 @@ void Blizzard::Invoker::Execute(command::Arena command) {
         const auto& tokenSlot = service->cache_[Domain::kToken];
         const auto& token = *tokenSlot.Get<std::string>();
         
-        constexpr uint64_t kSeason { 1 };
+        constexpr uint64_t kSeason { 2 };
         constexpr uint64_t kTeamSize { 2 };
         auto request = request::blizzard::Arena(kSeason, kTeamSize, token).Build();
         connection->ScheduleWrite(std::move(request), std::move(cb));

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -42,6 +42,19 @@ public:
 
     void Connect(std::function<void()> onConnect = {});
 
+    /**
+     * @brief Enque data to be sent when connection is able to write,
+     * i.e. `isWritting == false`
+     * 
+     * @param text data which will be enqued to the 
+     * switch buffer to be sent with other data at once according to scatter-gether idiom
+     * @param onWrite callback which will be invoked right after the banch of data will
+     * be sent to peer. Callback will be invoked in the same thread 
+     * as `OnWrite(const boost::system::error_code&, size_t)` being invoked.
+     * @note if there was a banch of data then the corresponding banch of callbacks will be invoked
+     * sequentially (see `OnWrite` implementation). This approach leads to following restrictions:
+     * - it MUST NOT block or do any "heavy" resource-consuming work.
+     */
     void ScheduleWrite(std::string text, std::function<void()> onWrite = {});
 
     virtual void Read(std::function<void()> onRead = {}) = 0;
@@ -84,7 +97,6 @@ protected:
 
     // === callbacks ===
     std::function<void()> onConnectSuccess_;
-    std::function<void()> onWriteSuccess_;
     std::function<void()> onReadSuccess_;
 
     // === Write ===

--- a/src/IrcShard.cpp
+++ b/src/IrcShard.cpp
@@ -2,6 +2,7 @@
 
 #include "Connection.hpp"
 #include "Request.hpp"
+#include "Utility.hpp"
 #include "Chain.hpp"
 #include "Console.hpp"
 #include "Config.hpp"
@@ -188,11 +189,14 @@ void IrcShard::HandlePrivateMessage(net::irc::Message& message) {
         std::string_view unprocessed { chatMessage };
         size_t chatCommandEnd = unprocessed.find_first_of(' ');
         if (chatCommandEnd == std::string_view::npos) {
+            assert(!unprocessed.empty());
             chatCommandEnd = unprocessed.size();
         }
+
         // here we're still not sure whether it's a command or just a coincidence
         std::string_view chatCommand { unprocessed.data() + 1, chatCommandEnd - 1 };
-        unprocessed.remove_prefix(chatCommandEnd + 1);
+        unprocessed.remove_prefix(chatCommandEnd);
+        unprocessed = utils::Trim(unprocessed);
         // divide message to tokens (maybe parameters for the chat command)
         auto params = command::ExtractArgs(unprocessed, ' ');
 

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -171,14 +171,15 @@ std::string RealmStatus::Build() const {
 
 std::string Arena::Build() const {
     assert(teamSize_ == 2 || teamSize_ == 3 || teamSize_ == 5);
-
+    
     const char *requestTemplate = 
-            "GET /data/wow/pvp-season/%1%/pvp-leaderboard/%2%v%2%?namespace=%3%&locale=%4% HTTP/1.1\r\n"
-            "Host: %5%.api.blizzard.com\r\n"
-            "Authorization: Bearer %6%\r\n"
+            "GET /data/wow/pvp-region/%1%/pvp-season/%2%/pvp-leaderboard/%3%v%3%?namespace=%4%&locale=%5% HTTP/1.1\r\n"
+            "Host: %6%.api.blizzard.com\r\n"
+            "Authorization: Bearer %7%\r\n"
             "\r\n";
     
     return (boost::format(requestTemplate) 
+        % region_
         % season_
         % teamSize_
         % kNamespace

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -1,8 +1,10 @@
 #include "Request.hpp"
+#include <cctype> // std::tolower
 #include <string>
 #include <string_view>
 #include <cstdint>
 #include <cassert>
+#include <algorithm>
 
 #include <boost/format.hpp>
 
@@ -93,6 +95,12 @@ std::string Leave::Build() const {
     return (boost::format(requestTemplate) % channel_).str();
 }
 
+Join::Join(const std::string& channel)
+    : channel_ { channel }
+{
+    std::transform(channel_.cbegin(), channel_.cend(), channel_.begin()
+        , [](unsigned char ch) { return std::tolower(ch); });
+}
 
 std::string Join::Build() const {
     // https://datatracker.ietf.org/doc/html/rfc1459.html#section-1.3

--- a/src/Request.hpp
+++ b/src/Request.hpp
@@ -70,8 +70,7 @@ namespace twitch {
     class Join : public Query {
     public:
 
-        Join(const std::string& channel) 
-            : channel_ { channel } {}
+        Join(const std::string& channel);
 
         std::string Build() const override;
 

--- a/src/Request.hpp
+++ b/src/Request.hpp
@@ -185,7 +185,8 @@ namespace blizzard {
             , std::uint64_t teamSize
             , const std::string& token
         )   
-            : season_ { season }
+            : region_ { 0 } // TODO: I don't know what it means but it was added to API
+            , season_ { season }
             , teamSize_ { teamSize }
             , token_ { token }
         {}
@@ -193,6 +194,7 @@ namespace blizzard {
         std::string Build() const override;
 
     private:
+        std::uint64_t region_;
         std::uint64_t season_;
         std::uint64_t teamSize_;
         std::string token_;

--- a/src/SwitchBuffer.hpp
+++ b/src/SwitchBuffer.hpp
@@ -3,24 +3,28 @@
 #include <array>
 #include <vector>
 #include <cassert>
+#include <functional>
 
 #include <boost/asio.hpp>
 
 class SwitchBuffer {
 public:
+    using ConstBuffer = boost::asio::const_buffer;
+    using FuncRef = std::reference_wrapper<std::function<void()>>;
+
     SwitchBuffer(size_t reserved = 10) {
         for (auto& buffer: buffers_) {
-            buffer.reserve(reserved);
+            buffer.Reserve(reserved);
         }
-        bufferSequence_.reserve(reserved);
+        bufferSequence_.Reserve(reserved);
     }
 
     /**
-     * Queue data to passibe buffer. 
+     * Queue data to passive buffer. 
      */
-    void Enque(std::string data) {
+    void Enque(std::string data, std::function<void()> callback) {
         assert(activeBuffer_ < buffers_.size());
-        buffers_[activeBuffer_ ^ 1].emplace_back(std::move(data));
+        buffers_[activeBuffer_ ^ 1].Append(std::move(data), std::move(callback));
     }
 
     /**
@@ -29,27 +33,82 @@ public:
     void SwapBuffers() {
         assert(activeBuffer_ < buffers_.size());
 
-        bufferSequence_.clear();
-        buffers_[activeBuffer_].clear();
+        bufferSequence_.Clear();
+        buffers_[activeBuffer_].Clear();
         activeBuffer_ ^= 1;
 
-        for (const auto& buf: buffers_[activeBuffer_]) {
-            bufferSequence_.emplace_back(boost::asio::const_buffer(buf.c_str(), buf.size()));
+        auto& buffer = buffers_[activeBuffer_];
+        for (size_t i = 0; i < buffer.Size(); i++) {
+            bufferSequence_.Append(buffer.data[i], buffer.callbacks[i]);
         }
     }
 
     size_t GetQueueSize() const noexcept {
         assert(activeBuffer_ < buffers_.size());
-        return buffers_[activeBuffer_ ^ 1].size();
+        return buffers_[activeBuffer_ ^ 1].Size();
     } 
 
-    const std::vector<boost::asio::const_buffer>& GetBufferSequence() const noexcept {
-        return bufferSequence_;
+    const std::vector<ConstBuffer>& GetBufferSequence() const noexcept {
+        return bufferSequence_.data;
+    }
+
+    const std::vector<FuncRef>& GetCallbackSequence() const noexcept {
+        return bufferSequence_.callbacks;
     }
 
 private:
+    // TODO: get rid of code duplication
+    struct BufferData {
+        std::vector<std::string> data;
+        std::vector<std::function<void()>> callbacks;
 
-    using DoubleBuffer = std::array<std::vector<std::string>, 2>;
+        void Append(std::string text, std::function<void()> callback) {
+            data.push_back(std::move(text));
+            callbacks.push_back(std::move(callback));
+        }
+
+        void Reserve(size_t n) {
+            data.reserve(n);
+            callbacks.reserve(n);
+        }
+
+        void Clear() noexcept {
+            data.clear();
+            callbacks.clear();
+        }
+
+        size_t Size() const noexcept {
+            assert(data.size() == callbacks.size());
+            return data.size();
+        }
+    };
+
+    struct BufferView {
+        std::vector<ConstBuffer> data;
+        std::vector<FuncRef> callbacks;
+
+        void Append(const std::string& text, std::function<void()>& callback) {
+            data.emplace_back(text.data(), text.size());
+            callbacks.emplace_back(std::ref(callback));
+        }
+
+        void Reserve(size_t n) {
+            data.reserve(n);
+            callbacks.reserve(n);
+        }
+
+        void Clear() noexcept {
+            data.clear();
+            callbacks.clear();
+        }
+
+        size_t Size() const noexcept {
+            assert(data.size() == callbacks.size());
+            return data.size();
+        }
+    };
+
+    using DoubleBuffer = std::array<BufferData, 2>;
 
     /**
      * Represent two sequences of some buffers
@@ -61,7 +120,7 @@ private:
     /**
      * View const buffer sequence used by write operations. 
      */
-    std::vector<boost::asio::const_buffer> bufferSequence_;
+    BufferView bufferSequence_;
     
     size_t activeBuffer_ { 0 };
 };


### PR DESCRIPTION
Save callbacks and execute them later sequentially